### PR TITLE
more for case study

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -318,6 +318,7 @@ No normalization of operators. Both backends handle all comparison directions.
 | `expr \|\| default` (on string/array) | if non-empty | `if \|expr\| > 0 then expr else default` |
 | `expr?.method(args)` | — | `if key in map { ... }` |
 | `expr as T` | stripped | stripped |
+| `null` | `none` | `None` (same as `undefined`) |
 | `new Map(arr.map(fn))` | — | loop building `map[]` |
 | `[a, b, c]` | `#[a, b, c]` | `[a, b, c]` |
 | `[...arr, e]` | `Array.push arr e` | `(arr + [e])` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -324,6 +324,7 @@ No normalization of operators. Both backends handle all comparison directions.
 | `new Map(arr.map(fn))` | — | loop building `map[]` |
 | `[a, b, c]` | `#[a, b, c]` | `[a, b, c]` |
 | `[...arr, e]` | `Array.push arr e` | `(arr + [e])` |
+| `arr.concat(e)` | — | `(arr + [e])` |
 | `{ ...obj, f: v }` | `{ obj with f := v }` | `obj.(f := v)` |
 | `arr.with(i, v)` | `arr.set! i v` | `arr[i := v]` |
 | `` `${n} items` `` (int+string) | — | `NatToString(n) + " items"` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -293,6 +293,8 @@ No normalization of operators. Both backends handle all comparison directions.
 | `Math.floor(n)` (int arg) | identity | identity |
 | `Math.ceil(n)` (int arg) | identity | identity |
 | `Math.abs(x)` | `MathAbs(x)` | `MathAbs(x)` (preamble: `if x >= 0 then x else -x`) |
+| `Math.min(a, b)` | `MathMin(a, b)` | `MathMin(a, b)` (preamble: `if a <= b then a else b`) |
+| `Math.max(a, b)` | `MathMax(a, b)` | `MathMax(a, b)` (preamble: `if a >= b then a else b`) |
 | `c ? a : b` | `if c then a else b` | `if c then a else b` |
 | `opt ? f(opt) : undefined` | match on Some/None | `match opt { case Some(v) => Some(f(v)) case None => None }` |
 | `s.indexOf(sub)` | `JSString.indexOf s sub` | `StringIndexOf(s, sub)` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,7 +39,8 @@ Annotations are TypeScript comments of the form `//@ <keyword> <expression>`.
 | `ghost x = e` | Before any statement | Ghost variable reassignment. |
 | `assert e` | Before any statement | Assertion (`assertGadget` in Lean, `assert` in Dafny). |
 | `havoc` | Before a variable declaration | Nondeterministic value — skip init expression (see §2.9). |
-| `havoc <key>` | Before a variable declaration | Nondeterministic subexpression — replace calls matching `<key>` (see §2.9). |
+| `havoc <key>` | Before a variable declaration | Nondeterministic subexpression — replace calls matching `<key>` (see §2.10). |
+| `declare-type N { f: T, ... }` | Before any statement | Declare a record type for cross-file types (see §2.5). |
 
 ### 2.2 Spec Expression Grammar
 
@@ -110,7 +111,20 @@ export interface Model {
 }
 ```
 
-### 2.5 Selective Verification: `//@ verify`
+### 2.5 Type Declarations: `//@ declare-type`
+
+When imported types can't be resolved by ts-morph (e.g., in monorepos with bundler module resolution), declare them manually:
+
+```typescript
+//@ declare-type Box { x: number, y: number, x2: number, y2: number }
+//@ declare-type Rect { x: number, y: number, width: number, height: number }
+```
+
+Each `declare-type` generates a Dafny `datatype` (or Lean `structure`) with the given fields. Field types use TS syntax (`number`, `string`, `boolean`, `T[]`, etc.) and are mapped through the standard type rules (§6.1).
+
+Place `declare-type` annotations before the first function that uses the type. They can appear as leading comments on any statement.
+
+### 2.6 Selective Verification: `//@ verify`
 
 By default, `lsc` extracts and verifies every function in the file. In brownfield codebases where most functions are outside the supported fragment, add `//@ verify` to opt in individual functions:
 
@@ -128,7 +142,7 @@ function isEmptyResult(result: string): boolean {
 
 If no function in the file has `//@ verify`, all functions are extracted as before. This keeps existing LemmaScript projects (where every function is in-fragment) working without changes.
 
-### 2.6 Backend Restriction: `//@ backend`
+### 2.7 Backend Restriction: `//@ backend`
 
 A file-level directive that restricts the file to a specific backend:
 
@@ -138,7 +152,7 @@ A file-level directive that restricts the file to a specific backend:
 
 When `lsc` runs with a different backend (e.g., `--backend=lean`), the file is silently skipped. This is used for features only supported in one backend, such as class methods (Dafny only).
 
-### 2.7 Classes
+### 2.8 Classes
 
 Class methods can be verified with `//@ verify`. The class fields become Dafny class fields, and `this.field` references work directly.
 
@@ -182,7 +196,7 @@ class Counter {
 
 **Lean:** Class support is Dafny-only. Use `//@ backend dafny` on files with classes.
 
-### 2.9 Havoc: `//@ havoc`
+### 2.10 Havoc: `//@ havoc`
 
 Marks a variable declaration as nondeterministic — the init expression is
 discarded and the variable receives an arbitrary value of its declared type:

--- a/SPEC.md
+++ b/SPEC.md
@@ -41,6 +41,7 @@ Annotations are TypeScript comments of the form `//@ <keyword> <expression>`.
 | `havoc` | Before a variable declaration | Nondeterministic value — skip init expression (see §2.9). |
 | `havoc <key>` | Before a variable declaration | Nondeterministic subexpression — replace calls matching `<key>` (see §2.10). |
 | `declare-type N { f: T, ... }` | Before any statement | Declare a record type for cross-file types (see §2.5). |
+| `skip` | Before any statement | Omit statement from verification model (for side-effect-only code). |
 
 ### 2.2 Spec Expression Grammar
 
@@ -319,6 +320,7 @@ No normalization of operators. Both backends handle all comparison directions.
 | `expr?.method(args)` | — | `if key in map { ... }` |
 | `expr as T` | stripped | stripped |
 | `null` | `none` | `None` (same as `undefined`) |
+| `//@ skip` (before statement) | — | statement omitted from model |
 | `new Map(arr.map(fn))` | — | loop building `map[]` |
 | `[a, b, c]` | `#[a, b, c]` | `[a, b, c]` |
 | `[...arr, e]` | `Array.push arr e` | `(arr + [e])` |

--- a/tools/src/dafny-emit.ts
+++ b/tools/src/dafny-emit.ts
@@ -234,7 +234,17 @@ function emitExpr(e: Expr): string {
         const updates = e.fields.map(f => `${escapeName(f.name)} := ${emitExpr(f.value)}`);
         return `${emitExpr(e.spread)}.(${updates.join(", ")})`;
       }
-      const ctorName = e.fields.length > 0 ? _recordCtors.get(e.fields[0].name) : undefined;
+      // Match constructor by field names — prefer exact match over first-field heuristic
+      let ctorName: string | undefined;
+      if (e.fields.length > 0) {
+        const fieldNames = new Set(e.fields.map(f => f.name));
+        for (const [name, fields] of _structureDecls) {
+          if (fields.length >= e.fields.length && fields.every(f => fieldNames.has(f.name) || f.type.kind === "optional")) {
+            ctorName = name; break;
+          }
+        }
+        if (!ctorName) ctorName = _recordCtors.get(e.fields[0].name);
+      }
       if (ctorName) {
         const structFields = _structureDecls.get(ctorName);
         if (structFields && e.fields.length < structFields.length) {

--- a/tools/src/dafny-emit.ts
+++ b/tools/src/dafny-emit.ts
@@ -88,6 +88,7 @@ function emitExpr(e: Expr): string {
         if (e.method === "with")     return `${obj}[${args[0]} := ${args[1]}]`;
         if (e.method === "includes") return `(${args[0]} in ${obj})`;
         if (e.method === "push")     return `(${obj} + [${args[0]}])`;
+        if (e.method === "concat")   return `(${obj} + [${args[0]}])`;
         if (e.method === "slice")    return `${obj}[${args[0]}..]`;
         if (e.method === "map")    { needsStdCollections = true; return `Seq.Map(${args[0]}, ${obj})`; }
         if (e.method === "filter") { needsStdCollections = true; return `Seq.Filter(${args[0]}, ${obj})`; }

--- a/tools/src/dafny-emit.ts
+++ b/tools/src/dafny-emit.ts
@@ -211,6 +211,8 @@ function emitExpr(e: Expr): string {
       if (e.fn === "FloorReal") needsFloorReal = true;
       if (e.fn === "NatToString") needsNatToString = true;
       if (e.fn === "MathAbs") needsMathAbs = true;
+      if (e.fn === "MathMin") needsMathMin = true;
+      if (e.fn === "MathMax") needsMathMax = true;
       return `${e.fn}(${args.join(", ")})`;
     }
 
@@ -508,6 +510,8 @@ let needsBitAnd = false;
 let needsPow2 = false;
 let needsNatToString = false;
 let needsMathAbs = false;
+let needsMathMin = false;
+let needsMathMax = false;
 
 const POW2 = `function Pow2(n: int): int
   requires n >= 0
@@ -605,6 +609,9 @@ const STRING_TO_UPPER = `function StringToUpper(s: string): string
     [upper] + StringToUpper(s[1..])
 }`;
 
+const MATH_MIN = `function MathMin(a: int, b: int): int { if a <= b then a else b }`;
+const MATH_MAX = `function MathMax(a: int, b: int): int { if a >= b then a else b }`;
+
 const NAT_TO_STRING = `function NatToString(n: nat): string
   decreases n
 {
@@ -693,6 +700,8 @@ export function emitDafnyFile(file: Module, tsFileName?: string): string {
   needsPow2 = false;
   needsNatToString = false;
   needsMathAbs = false;
+  needsMathMin = false;
+  needsMathMax = false;
 
   // Collect pure def names so we can skip their method wrappers
   const pureDefs = new Set<string>();
@@ -759,6 +768,8 @@ export function emitDafnyFile(file: Module, tsFileName?: string): string {
   if (needsStringToUpper) { lines.push(""); lines.push(STRING_TO_UPPER); }
   if (needsNatToString) { lines.push(""); lines.push(NAT_TO_STRING); }
   if (needsMathAbs) { lines.push(""); lines.push(MATH_ABS); }
+  if (needsMathMin) { lines.push(""); lines.push(MATH_MIN); }
+  if (needsMathMax) { lines.push(""); lines.push(MATH_MAX); }
   lines.push(...declLines);
   return lines.join("\n") + "\n";
 }

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -657,7 +657,13 @@ function extractFunction(fn: FunctionDeclaration, parentAnnotations?: Annotation
       }
       return [{ name: p.getName(), tsType: p.getTypeNode()?.getText() ?? "unknown" }];
     }),
-    returnType: fn.getReturnTypeNode()?.getText() ?? "unknown",
+    returnType: (() => {
+      const node = fn.getReturnTypeNode();
+      if (node) return node.getText();
+      const inferred = fn.getReturnType();
+      if (inferred.isAny()) return "unknown";
+      return typeToString(inferred);
+    })(),
     requires: annots.filter(a => a.kind === "requires").map(a => a.expr),
     ensures: annots.filter(a => a.kind === "ensures").map(a => a.expr),
     typeAnnotations,

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -201,6 +201,11 @@ function extractExpr(node: Expression): RawExpr {
     return extractExpr(node.getExpression());
   }
 
+  // null → undefined (both map to None in backends)
+  if (Node.isNullLiteral(node)) {
+    return { kind: "var", name: "undefined" };
+  }
+
   throw new Error(`Unsupported expression: ${node.getText()}`);
 }
 

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -670,6 +670,39 @@ function extractFunction(fn: FunctionDeclaration, parentAnnotations?: Annotation
 
 export function extractModule(sourceFile: SourceFile): RawModule {
   const typeDecls: TypeDeclInfo[] = [];
+
+  // Parse //@ declare-type directives from file comments
+  for (const range of sourceFile.getLeadingCommentRanges()) {
+    const text = range.getText().trim();
+    if (!text.startsWith("//@ declare-type ")) continue;
+    const body = text.slice("//@ declare-type ".length);
+    const match = body.match(/^(\w+)\s*\{(.+)\}$/);
+    if (!match) continue;
+    const name = match[1];
+    const fieldsStr = match[2];
+    const fields = fieldsStr.split(",").map(f => f.trim()).filter(Boolean).map(f => {
+      const [fname, ftype] = f.split(":").map(s => s.trim());
+      return { name: fname, tsType: ftype };
+    });
+    typeDecls.push({ name, kind: "record", fields });
+  }
+  // Also scan statement-level comments for declare-type
+  for (const stmt of sourceFile.getStatements()) {
+    for (const range of stmt.getLeadingCommentRanges()) {
+      const text = range.getText().trim();
+      if (!text.startsWith("//@ declare-type ")) continue;
+      const body = text.slice("//@ declare-type ".length);
+      const match = body.match(/^(\w+)\s*\{(.+)\}$/);
+      if (!match) continue;
+      const name = match[1];
+      const fields = match[2].split(",").map(f => f.trim()).filter(Boolean).map(f => {
+        const [fname, ftype] = f.split(":").map(s => s.trim());
+        return { name: fname, tsType: ftype };
+      });
+      typeDecls.push({ name, kind: "record", fields });
+    }
+  }
+
   // Extract type declarations in source order to respect dependencies
   for (const stmt of sourceFile.getStatements()) {
     if (Node.isTypeAliasDeclaration(stmt)) {

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -262,7 +262,7 @@ function extractTypeDecl(decl: TypeAliasDeclaration, extraDecls?: TypeDeclInfo[]
     }
   }
 
-  if (type.isObject()) return extractRecord(name, type, decl, undefined, extraDecls);
+  if (type.isObject() || type.isIntersection()) return extractRecord(name, type, decl, undefined, extraDecls);
   return null;
 }
 
@@ -616,11 +616,23 @@ function extractStmts(stmts: Node[]): RawStmt[] {
 
 // ── Function extraction ──────────────────────────────────────
 
-function extractFunction(fn: FunctionDeclaration): RawFunction {
+function extractFunction(fn: FunctionDeclaration, parentAnnotations?: Annotation[]): RawFunction {
   const body = fn.getBody();
-  if (!body || !Node.isBlock(body)) throw new Error(`${(fn as any).getName?.() ?? "arrow"}: function body is not a block`);
-  const bodyStmts = body.getStatements();
-  const annots = collectAnnotations(fn, bodyStmts);
+
+  // Expression-body arrow: wrap in implicit return
+  let extractedBody: RawStmt[];
+  let annots: Annotation[];
+  if (body && !Node.isBlock(body)) {
+    const expr = extractExpr(body as Expression);
+    extractedBody = [{ kind: "return", value: expr, line: body.getStartLineNumber() }];
+    annots = parentAnnotations ?? collectAnnotations(fn);
+  } else if (body && Node.isBlock(body)) {
+    const bodyStmts = body.getStatements();
+    extractedBody = extractStmts(bodyStmts);
+    annots = collectAnnotations(fn, bodyStmts);
+  } else {
+    throw new Error(`${(fn as any).getName?.() ?? "arrow"}: function has no body`);
+  }
 
   const typeAnnotations: { name: string; type: string }[] = [];
   for (const a of annots) {
@@ -649,7 +661,7 @@ function extractFunction(fn: FunctionDeclaration): RawFunction {
     requires: annots.filter(a => a.kind === "requires").map(a => a.expr),
     ensures: annots.filter(a => a.kind === "ensures").map(a => a.expr),
     typeAnnotations,
-    body: extractStmts(bodyStmts),
+    body: extractedBody,
     line: fn.getStartLineNumber(),
   };
 }
@@ -701,31 +713,40 @@ export function extractModule(sourceFile: SourceFile): RawModule {
   }
 
   // Collect all function-like declarations: function declarations + const arrow functions
-  const allFns: { name: string; node: FunctionDeclaration }[] = [];
+  const allFns: { name: string; node: FunctionDeclaration; parentStmt?: Node }[] = [];
   for (const fn of sourceFile.getFunctions()) {
     allFns.push({ name: fn.getName() ?? "<anonymous>", node: fn });
   }
-  // const f = (...) => { ... } — treat as named function
+  // const f = (...) => expr  OR  const f = (...) => { ... }
   for (const stmt of sourceFile.getStatements()) {
     if (Node.isVariableStatement(stmt)) {
       for (const decl of stmt.getDeclarationList().getDeclarations()) {
         const init = decl.getInitializer();
         if (init && Node.isArrowFunction(init)) {
-          allFns.push({ name: decl.getName(), node: init as unknown as FunctionDeclaration });
+          allFns.push({ name: decl.getName(), node: init as unknown as FunctionDeclaration, parentStmt: stmt });
         }
       }
     }
   }
 
   // If any function has //@ verify, only extract those (brownfield mode).
-  // Otherwise extract all functions (backwards-compatible with existing examples).
-  const hasVerifyDirective = allFns.some(f => f.node.getFullText().includes('//@ verify'));
-  const fnsToExtract = hasVerifyDirective
-    ? allFns.filter(f => f.node.getFullText().includes('//@ verify'))
-    : allFns;
+  // For expression-body arrows, //@ verify may be on the parent variable statement.
+  function hasVerify(f: { node: FunctionDeclaration; parentStmt?: Node }) {
+    if (f.node.getFullText().includes('//@ verify')) return true;
+    if (f.parentStmt) {
+      for (const r of f.parentStmt.getLeadingCommentRanges()) {
+        if (r.getText().includes('//@ verify')) return true;
+      }
+    }
+    return false;
+  }
+  const hasVerifyDirective = allFns.some(hasVerify);
+  const fnsToExtract = hasVerifyDirective ? allFns.filter(hasVerify) : allFns;
 
   const functions = fnsToExtract.map(f => {
-    const raw = extractFunction(f.node);
+    // For expression-body arrows, annotations come from the parent variable statement
+    const parentAnnots = f.parentStmt ? parseAnnotations(f.parentStmt) : undefined;
+    const raw = extractFunction(f.node, parentAnnots);
     raw.name = f.name;  // use the const name, not "<anonymous>"
     return raw;
   });
@@ -801,6 +822,11 @@ export function extractModule(sourceFile: SourceFile): RawModule {
           const extra: TypeDeclInfo[] = [];
           const info = extractTypeDecl(decls[0], extra);
           if (info) { typeDecls.push(...extra); typeDecls.push(info); knownTypes.add(aliasName); }
+        } else if (t.getProperties().length > 0) {
+          // Alias declaration not available (e.g. intersection type) — extract from properties
+          const extra: TypeDeclInfo[] = [];
+          const info = extractRecord(aliasName, t, locationNode, undefined, extra);
+          if (info) { typeDecls.push(...extra); typeDecls.push(info); knownTypes.add(aliasName); }
         }
       }
     }
@@ -808,7 +834,7 @@ export function extractModule(sourceFile: SourceFile): RawModule {
     for (const arg of t.getTypeArguments()) resolveType(arg, locationNode);
     const sym = t.getSymbol() ?? t.getAliasSymbol();
     const name = sym?.getName();
-    if (name && !name.startsWith("__") && !knownTypes.has(name) && !builtins.has(name) && t.isObject()) {
+    if (name && !name.startsWith("__") && !knownTypes.has(name) && !builtins.has(name) && (t.isObject() || t.isIntersection())) {
       const extra: TypeDeclInfo[] = [];
       const info = extractRecord(name, t, locationNode, undefined, extra);
       if (info) {

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -417,7 +417,13 @@ function extractStmts(stmts: Node[]): RawStmt[] {
     const line = s.getStartLineNumber();
 
     // Ghost annotations from leading comments → inject before this statement
-    result.push(...parseSpecComments(s.getLeadingCommentRanges(), line));
+    const leadingComments = s.getLeadingCommentRanges();
+    result.push(...parseSpecComments(leadingComments, line));
+
+    // //@ skip — omit this statement from the verification model
+    if (leadingComments.some(r => r.getText().trim() === "//@ skip")) {
+      continue;
+    }
 
     if (Node.isVariableStatement(s)) {
       const havocMatch = s.getLeadingCommentRanges()

--- a/tools/src/lsc.ts
+++ b/tools/src/lsc.ts
@@ -65,6 +65,7 @@ function main() {
     ? new Project({ tsConfigFilePath, skipAddingFilesFromTsConfig: true })
     : new Project({ compilerOptions: { strict: true, target: ScriptTarget.ESNext, lib: ["lib.esnext.d.ts"] } });
   const sourceFile = project.addSourceFileAtPath(absPath);
+  project.resolveSourceFileDependencies();
 
   // Check //@ backend directive — skip if backend doesn't match
   const backendDirective = sourceFile.getFullText().match(/\/\/@ backend (\w+)/);

--- a/tools/src/resolve.ts
+++ b/tools/src/resolve.ts
@@ -311,6 +311,7 @@ function resolveExpr(e: RawExpr, ctx: Ctx): TExpr {
         if (fn.field === "includes") ty = { kind: "bool" };
         else if (fn.field === "shift") ty = fn.obj.ty.elem;
         else if (fn.field === "push") ty = fn.obj.ty;
+        else if (fn.field === "concat") ty = fn.obj.ty;
         else if (fn.field === "map" && args.length >= 1 && args[0].kind === "lambda") {
           const retTy = args[0].body.length > 0 && args[0].body[0].kind === "return"
             ? args[0].body[0].value.ty : { kind: "unknown" as const };

--- a/tools/src/transform.ts
+++ b/tools/src/transform.ts
@@ -314,9 +314,14 @@ function lowerExpr(e: TExpr, binds: Stmt[] | null): Expr {
     }
 
     case "call": {
-      // Math.abs(x): MathAbs preamble function (avoids if-else precedence in larger expressions)
-      if (e.fn.kind === "field" && e.fn.field === "abs" && e.fn.obj.kind === "var" && e.fn.obj.name === "Math" && e.args.length === 1) {
-        return { kind: "app", fn: "MathAbs", args: [lowerExpr(e.args[0], binds)] };
+      // Math.abs/min/max → preamble functions
+      if (e.fn.kind === "field" && e.fn.obj.kind === "var" && e.fn.obj.name === "Math") {
+        if (e.fn.field === "abs" && e.args.length === 1)
+          return { kind: "app", fn: "MathAbs", args: [lowerExpr(e.args[0], binds)] };
+        if (e.fn.field === "min" && e.args.length === 2)
+          return { kind: "app", fn: "MathMin", args: e.args.map(a => lowerExpr(a, binds)) };
+        if (e.fn.field === "max" && e.args.length === 2)
+          return { kind: "app", fn: "MathMax", args: e.args.map(a => lowerExpr(a, binds)) };
       }
       // Math.ceil(x): CeilReal on real args, identity on int
       if (e.fn.kind === "field" && e.fn.field === "ceil" && e.fn.obj.kind === "var" && e.fn.obj.name === "Math" && e.args.length === 1) {


### PR DESCRIPTION
  Extract: support expression-body arrows (wrap in implicit return, collect
  annotations from parent variable statement). Handle intersection types
  (A & B) as record types in extractTypeDecl and resolveType. Fall back to
  property-based extraction when alias declarations aren't available.
  Lsc: resolve source file dependencies for import resolution.