### PR TITLE
Fix for case study.

### DIFF
--- a/examples/packet.def.lean
+++ b/examples/packet.def.lean
@@ -8,8 +8,8 @@ set_option loom.semantics.termination "total"
 set_option loom.semantics.choice "demonic"
 
 method nextSeq (state : Int) (pkt : Packet) return (res : Int)
-  ensures match pkt with | .syn _seq => res = _seq | _ => true
-  ensures match pkt with | .data _seq _len => res = state + _len | _ => true
+  ensures match pkt with | .syn _pkt_seq => res = _pkt_seq | _ => true
+  ensures match pkt with | .data _pkt_seq _pkt_len => res = state + _pkt_len | _ => true
   ensures match pkt with | .fin => res = state | _ => true
   do
     return Pure.nextSeq state pkt

--- a/examples/packet.dfy
+++ b/examples/packet.dfy
@@ -5,12 +5,12 @@ datatype Packet = syn(seq_: int) | ack(seq_: int) | data(seq_: int, len: int) | 
 function nextSeq(state: int, pkt: Packet): int
 {
   match pkt {
-    case syn(i_seq) =>
-      i_seq
-    case ack(i_seq) =>
+    case syn(i_pkt_seq) =>
+      i_pkt_seq
+    case ack(i_pkt_seq) =>
       state
-    case data(i_seq, i_len) =>
-      (state + i_len)
+    case data(i_pkt_seq, i_pkt_len) =>
+      (state + i_pkt_len)
     case _ =>
       state
   }

--- a/examples/packet.dfy.gen
+++ b/examples/packet.dfy.gen
@@ -5,12 +5,12 @@ datatype Packet = syn(seq_: int) | ack(seq_: int) | data(seq_: int, len: int) | 
 function nextSeq(state: int, pkt: Packet): int
 {
   match pkt {
-    case syn(i_seq) =>
-      i_seq
-    case ack(i_seq) =>
+    case syn(i_pkt_seq) =>
+      i_pkt_seq
+    case ack(i_pkt_seq) =>
       state
-    case data(i_seq, i_len) =>
-      (state + i_len)
+    case data(i_pkt_seq, i_pkt_len) =>
+      (state + i_pkt_len)
     case _ =>
       state
   }

--- a/examples/packet.types.lean
+++ b/examples/packet.types.lean
@@ -14,12 +14,12 @@ namespace Pure
 
 def nextSeq (state : Int) (pkt : Packet) : Int :=
   match pkt with
-  | .syn _seq =>
-    _seq
-  | .ack _seq =>
+  | .syn _pkt_seq =>
+    _pkt_seq
+  | .ack _pkt_seq =>
     state
-  | .data _seq _len =>
-    state + _len
+  | .data _pkt_seq _pkt_len =>
+    state + _pkt_len
   | _ =>
     state
 

--- a/examples/spec.def.lean
+++ b/examples/spec.def.lean
@@ -8,15 +8,15 @@ set_option loom.semantics.termination "total"
 set_option loom.semantics.choice "demonic"
 
 method evalPartial (e : Expr) return (res : Int)
-  ensures match e with | .lit _val => res = _val | _ => true
-  ensures match e with | .add _a _b => res = _a + _b | _ => true
+  ensures match e with | .lit _e_val => res = _e_val | _ => true
+  ensures match e with | .add _e_a _e_b => res = _e_a + _e_b | _ => true
   do
     return Pure.evalPartial e
 
 method evalSwitch (e : Expr) return (res : Int)
-  ensures match e with | .lit _val => res = _val | _ => true
-  ensures match e with | .add _a _b => res = _a + _b | _ => true
-  ensures match e with | .neg _inner => res = 0 - _inner | _ => true
+  ensures match e with | .lit _e_val => res = _e_val | _ => true
+  ensures match e with | .add _e_a _e_b => res = _e_a + _e_b | _ => true
+  ensures match e with | .neg _e_inner => res = 0 - _e_inner | _ => true
   do
     return Pure.evalSwitch e
 

--- a/examples/spec.dfy
+++ b/examples/spec.dfy
@@ -35,10 +35,10 @@ datatype PriorityItem = PriorityItem(level: Priority, value: int)
 function evalPartial(e: Expr): int
 {
   match e {
-    case lit(i_val) =>
-      i_val
-    case add(i_a, i_b) =>
-      (i_a + i_b)
+    case lit(i_e_val) =>
+      i_e_val
+    case add(i_e_a, i_e_b) =>
+      (i_e_a + i_e_b)
     case _ =>
       0
   }
@@ -53,12 +53,12 @@ lemma evalPartial_ensures(e: Expr)
 function evalSwitch(e: Expr): int
 {
   match e {
-    case lit(i_val) =>
-      i_val
-    case add(i_a, i_b) =>
-      (i_a + i_b)
-    case neg(i_inner) =>
-      (0 - i_inner)
+    case lit(i_e_val) =>
+      i_e_val
+    case add(i_e_a, i_e_b) =>
+      (i_e_a + i_e_b)
+    case neg(i_e_inner) =>
+      (0 - i_e_inner)
   }
 }
 

--- a/examples/spec.dfy.gen
+++ b/examples/spec.dfy.gen
@@ -35,10 +35,10 @@ datatype PriorityItem = PriorityItem(level: Priority, value: int)
 function evalPartial(e: Expr): int
 {
   match e {
-    case lit(i_val) =>
-      i_val
-    case add(i_a, i_b) =>
-      (i_a + i_b)
+    case lit(i_e_val) =>
+      i_e_val
+    case add(i_e_a, i_e_b) =>
+      (i_e_a + i_e_b)
     case _ =>
       0
   }
@@ -53,12 +53,12 @@ lemma evalPartial_ensures(e: Expr)
 function evalSwitch(e: Expr): int
 {
   match e {
-    case lit(i_val) =>
-      i_val
-    case add(i_a, i_b) =>
-      (i_a + i_b)
-    case neg(i_inner) =>
-      (0 - i_inner)
+    case lit(i_e_val) =>
+      i_e_val
+    case add(i_e_a, i_e_b) =>
+      (i_e_a + i_e_b)
+    case neg(i_e_inner) =>
+      (0 - i_e_inner)
   }
 }
 

--- a/examples/spec.types.lean
+++ b/examples/spec.types.lean
@@ -31,21 +31,21 @@ namespace Pure
 
 def evalPartial (e : Expr) : Int :=
   match e with
-  | .lit _val =>
-    _val
-  | .add _a _b =>
-    _a + _b
+  | .lit _e_val =>
+    _e_val
+  | .add _e_a _e_b =>
+    _e_a + _e_b
   | _ =>
     0
 
 def evalSwitch (e : Expr) : Int :=
   match e with
-  | .lit _val =>
-    _val
-  | .add _a _b =>
-    _a + _b
-  | .neg _inner =>
-    0 - _inner
+  | .lit _e_val =>
+    _e_val
+  | .add _e_a _e_b =>
+    _e_a + _e_b
+  | .neg _e_inner =>
+    0 - _e_inner
 
 def isHighPriority (p : Priority) : Bool :=
   if p = .high then

--- a/tools/src/dafny-emit.ts
+++ b/tools/src/dafny-emit.ts
@@ -210,6 +210,8 @@ function emitExpr(e: Expr): string {
       const args = e.args.map(emitExpr);
       if (e.fn === "SetToSeq") { needsSetToSeq = true; return `SetToSeq(${args.join(", ")})`; }
       if (e.fn === "BigInt" || e.fn === "Number") return args[0]; // identity: both map to int
+      // Set literal: {a, b, c}
+      if (e.fn === "SetLiteral") return `{${args.join(", ")}}`;
       if (e.fn === "JSFloorDiv") needsJSFloorDiv = true;
       if (e.fn === "CeilReal") needsCeilReal = true;
       if (e.fn === "FloorReal") needsFloorReal = true;
@@ -217,7 +219,7 @@ function emitExpr(e: Expr): string {
       if (e.fn === "MathAbs") needsMathAbs = true;
       if (e.fn === "MathMin") needsMathMin = true;
       if (e.fn === "MathMax") needsMathMax = true;
-      return `${e.fn}(${args.join(", ")})`;
+      return `${escapeName(e.fn)}(${args.join(", ")})`;
     }
 
     case "field": {

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -755,7 +755,10 @@ function extractFunction(fn: FunctionDeclaration, parentAnnotations?: Annotation
           return { name, tsType: propType ? typeToString(propType) : "unknown" };
         });
       }
-      return [{ name: p.getName(), tsType: _eraseGenerics(p.getTypeNode()?.getText() ?? "unknown") }];
+      let tsType = _eraseGenerics(p.getTypeNode()?.getText() ?? "unknown");
+      // Optional parameters (foo?: T) need | undefined in the type string
+      if (p.hasQuestionToken()) tsType = `${tsType} | undefined`;
+      return [{ name: p.getName(), tsType }];
     }),
     returnType: (() => {
       const node = fn.getReturnTypeNode();

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -219,13 +219,23 @@ function extractExpr(node: Expression): RawExpr {
     const name = node.getExpression().getText();
     if (name === "Map" || name === "Set") {
       const typeArgs = node.getTypeArguments();
+      // Use explicit type args if present, otherwise infer from TS type system
       const tsType = typeArgs && typeArgs.length > 0
         ? `${name}<${typeArgs.map(t => t.getText()).join(", ")}>`
-        : name;
+        : _eraseGenerics(typeToString(node.getType()));
       const args = node.getArguments();
-      // new Map(arr.map(fn)) — map-from-array constructor
+      // new Map(existingMap) — pass through (Dafny/Lean maps are value types)
       if (name === "Map" && args && args.length === 1) {
-        return { kind: "call", fn: { kind: "var", name: "__mapFromArray" }, args: [extractExpr(args[0] as Expression)] };
+        return extractExpr(args[0] as Expression);
+      }
+      // new Set([a, b, c]) — set with initial elements
+      if (name === "Set" && args && args.length === 1) {
+        const arg = args[0] as Expression;
+        if (Node.isArrayLiteralExpression(arg)) {
+          return { kind: "emptyCollection", collectionType: "Set", tsType, initElems: arg.getElements().map(e => extractExpr(e as Expression)) };
+        }
+        // new Set(existingSet) — pass through
+        return extractExpr(arg);
       }
       return { kind: "emptyCollection", collectionType: name as "Map" | "Set", tsType };
     }

--- a/tools/src/extract.ts
+++ b/tools/src/extract.ts
@@ -224,9 +224,16 @@ function extractExpr(node: Expression): RawExpr {
         ? `${name}<${typeArgs.map(t => t.getText()).join(", ")}>`
         : _eraseGenerics(typeToString(node.getType()));
       const args = node.getArguments();
-      // new Map(existingMap) — pass through (Dafny/Lean maps are value types)
+      // new Map(source) — clone existing map or build from entries
       if (name === "Map" && args && args.length === 1) {
-        return extractExpr(args[0] as Expression);
+        const argType = (args[0] as Expression).getType();
+        const argSymbol = argType.getSymbol()?.getName() ?? argType.getAliasSymbol()?.getName();
+        if (argSymbol === "Map") {
+          // new Map(existingMap) — identity (Dafny maps are value types)
+          return extractExpr(args[0] as Expression);
+        }
+        // new Map(entries) — map-from-array constructor
+        return { kind: "call", fn: { kind: "var", name: "__mapFromArray" }, args: [extractExpr(args[0] as Expression)] };
       }
       // new Set([a, b, c]) — set with initial elements
       if (name === "Set" && args && args.length === 1) {

--- a/tools/src/rawir.ts
+++ b/tools/src/rawir.ts
@@ -24,7 +24,7 @@ export type RawExpr =
   | { kind: "arrayLiteral"; elems: RawExpr[] }
   | { kind: "lambda"; params: { name: string; tsType?: string }[]; body: RawExpr | RawStmt[] }
   | { kind: "conditional"; cond: RawExpr; then: RawExpr; else: RawExpr }  // ternary ? :
-  | { kind: "emptyCollection"; collectionType: "Map" | "Set"; tsType: string }  // new Map<K,V>() / new Set<T>()
+  | { kind: "emptyCollection"; collectionType: "Map" | "Set"; tsType: string; initElems?: RawExpr[] }  // new Map<K,V>() / new Set<T>()
   | { kind: "nonNull"; expr: RawExpr }   // expr! (non-null assertion)
   // Spec-only (from //@ annotations, produced by specparser):
   | { kind: "result" }                                    // \result

--- a/tools/src/resolve.ts
+++ b/tools/src/resolve.ts
@@ -281,11 +281,15 @@ function resolveExpr(e: RawExpr, ctx: Ctx): TExpr {
         argCtx = { ...ctx, returnTy: fn.obj.ty.elem };
       }
       let args = rawArgs.map(a => resolveExpr(a, argCtx));
-      // Coerce non-optional args to Option when callee expects optional param: wrap in Some
+      // Coerce args: string literals to user types, non-optional to Option, pad missing optional args
       if (fn.kind === "var" && ctx.fnParams.has(fn.name)) {
         const paramTys = ctx.fnParams.get(fn.name)!;
         args = args.map((a, i) => {
-          if (i < paramTys.length && a.ty.kind !== "optional" && paramTys[i].kind === "optional") {
+          if (i >= paramTys.length) return a;
+          // Coerce string literal to user type (e.g., 'MissingList' → Err constructor)
+          a = coerceStr(a, paramTys[i]);
+          // Wrap non-optional in Some when callee expects optional param
+          if (a.ty.kind !== "optional" && paramTys[i].kind === "optional") {
             return {
               kind: "call" as const,
               fn: { kind: "var" as const, name: "Some", ty: paramTys[i] },
@@ -296,6 +300,12 @@ function resolveExpr(e: RawExpr, ctx: Ctx): TExpr {
           }
           return a;
         });
+        // Pad missing optional args with None
+        for (let i = args.length; i < paramTys.length; i++) {
+          if (paramTys[i].kind === "optional") {
+            args.push({ kind: "var" as const, name: "undefined", ty: paramTys[i] });
+          }
+        }
       }
       let ty: Ty = { kind: "unknown" };
       // Infer return types for collection methods
@@ -460,7 +470,8 @@ function resolveExpr(e: RawExpr, ctx: Ctx): TExpr {
 
     case "emptyCollection": {
       const ty = parseTsType(e.tsType);
-      return { kind: "arrayLiteral", elems: [], ty };
+      const elems = e.initElems ? e.initElems.map(el => resolveExpr(el, ctx)) : [];
+      return { kind: "arrayLiteral", elems, ty };
     }
 
     case "havoc":

--- a/tools/src/transform.ts
+++ b/tools/src/transform.ts
@@ -91,9 +91,14 @@ export const DAFNY_OPTIONS: TransformOptions = {
 /** Active options — set before each transform call. */
 let _opts: TransformOptions = DAFNY_OPTIONS;
 
-/** Prefix match-bound field names to avoid capturing user variables. */
-function matchBinder(fieldName: string): string {
-  return `_${fieldName}`;
+/** Type declarations — set once per module transform for discriminated union handling. */
+let _typeDecls: TypeDeclInfo[] = [];
+
+/** Prefix match-bound field names to avoid capturing user variables.
+ *  When prefix is given (the scrutinee name), include it to avoid
+ *  collisions in nested matches on different variables. */
+function matchBinder(fieldName: string, prefix?: string): string {
+  return prefix ? `_${prefix}_${fieldName}` : `_${fieldName}`;
 }
 
 const _forofCounters = new Map<string, number>();
@@ -371,12 +376,39 @@ function lowerExpr(e: TExpr, binds: Stmt[] | null): Expr {
       return { kind: "app", fn: prefix + e.fn.name, args: e.args.map(a => lowerExpr(a, binds)) };
     }
 
-    case "record":
+    case "record": {
+      // Discriminated union: { kind: 'NoOp' } → constructor NoOp
+      if (e.ty.kind === "user" && !e.spread) {
+        const tyName = e.ty.name;
+        const decl = _typeDecls.find(d => d.name === tyName && (d.kind === "discriminated-union" || d.kind === "string-union"));
+        if (decl && decl.discriminant) {
+          const discField = e.fields.find(f => f.name === decl.discriminant);
+          if (discField && (discField.value.kind === "str" || discField.value.kind === "bool")) {
+            const variantName = String(discField.value.kind === "str" ? discField.value.value : discField.value.value);
+            const variant = decl.variants?.find(v => v.name === variantName);
+            if (variant) {
+              const nonDiscFields = e.fields.filter(f => f.name !== decl.discriminant);
+              if (nonDiscFields.length === 0) {
+                return { kind: "constructor", name: variantName, type: tyName };
+              }
+              // Constructor with args: match variant field order
+              const args = variant.fields.map(vf => {
+                const ef = nonDiscFields.find(f => f.name === vf.name);
+                return ef ? lowerExpr(ef.value, binds) : { kind: "var" as const, name: "None" };
+              });
+              return { kind: "app", fn: variantName, args };
+            }
+          }
+        }
+      }
       return { kind: "record", spread: e.spread ? lowerExpr(e.spread, binds) : null, fields: e.fields.map(f => ({ name: f.name, value: lowerExpr(f.value, binds) })) };
+    }
 
     case "arrayLiteral":
       if (e.ty.kind === "map" && e.elems.length === 0) return { kind: "emptyMap" };
       if (e.ty.kind === "set" && e.elems.length === 0) return { kind: "emptySet" };
+      // Set with initial elements: new Set([a, b]) → {a, b}
+      if (e.ty.kind === "set") return { kind: "app", fn: "SetLiteral", args: e.elems.map(el => lowerExpr(el, binds)) };
       return { kind: "arrayLiteral", elems: e.elems.map(el => lowerExpr(el, binds)) };
 
     case "lambda":
@@ -476,7 +508,7 @@ function ensuresToMatch(e: TExpr, typeDecls: TypeDeclInfo[]): Expr | null {
   if (!variant) return null;
 
   const fields = variant.fields;
-  const pattern = fields.length > 0 ? `.${variantName} ${fields.map(f => matchBinder(f.name)).join(" ")}` : `.${variantName}`;
+  const pattern = fields.length > 0 ? `.${variantName} ${fields.map(f => matchBinder(f.name, obj.name)).join(" ")}` : `.${variantName}`;
 
   let rhs = transformExpr(e.right);
   rhs = replaceFieldAccess(rhs, obj.name, fields);
@@ -488,7 +520,7 @@ function replaceFieldAccess(e: Expr, varName: string, fields: { name: string; ts
   return mapExpr(e, x => {
     if (x.kind === "field" && x.obj.kind === "var" && x.obj.name === varName) {
       const f = fields.find(f => f.name === x.field);
-      if (f) return { kind: "var", name: matchBinder(f.name) };
+      if (f) return { kind: "var", name: matchBinder(f.name, varName) };
     }
     // If this let shadows the matched variable, stop replacing in the body
     if (x.kind === "let" && x.name === varName) return { ...x, value: replaceFieldAccess(x.value, varName, fields) };
@@ -852,7 +884,7 @@ function emitMatchStmt(chain: Chain, typeDecls: TypeDeclInfo[]): Stmt {
   const arms: StmtMatchArm[] = chain.cases.map(c => {
     const variant = decl?.variants?.find(v => v.name === c.variant);
     const fields = variant?.fields ?? [];
-    const pattern = fields.length > 0 ? `.${c.variant} ${fields.map(f => matchBinder(f.name)).join(" ")}` : `.${c.variant}`;
+    const pattern = fields.length > 0 ? `.${c.variant} ${fields.map(f => matchBinder(f.name, chain.varName)).join(" ")}` : `.${c.variant}`;
     let body = transformStmts(c.body, typeDecls);
     body = replaceFieldAccessInStmts(body, chain.varName, fields);
     return { pattern, body };
@@ -868,7 +900,7 @@ function emitSwitchStmt(s: TStmt & { kind: "switch" }, typeDecls: TypeDeclInfo[]
   const arms: StmtMatchArm[] = s.cases.map(c => {
     const variant = decl?.variants?.find(v => v.name === c.label);
     const fields = variant?.fields ?? [];
-    const pattern = fields.length > 0 ? `.${c.label} ${fields.map(f => matchBinder(f.name)).join(" ")}` : `.${c.label}`;
+    const pattern = fields.length > 0 ? `.${c.label} ${fields.map(f => matchBinder(f.name, varName)).join(" ")}` : `.${c.label}`;
     let body = transformStmts(c.body, typeDecls);
     body = replaceFieldAccessInStmts(body, varName, fields);
     return { pattern, body };
@@ -882,7 +914,7 @@ function replaceFieldAccessInStmts(stmts: Stmt[], varName: string, fields: { nam
   const f = (e: Expr): Expr | null => {
     if (e.kind === "field" && e.obj.kind === "var" && e.obj.name === varName) {
       const fi = fields.find(fi => fi.name === e.field);
-      if (fi) return { kind: "var", name: matchBinder(fi.name) };
+      if (fi) return { kind: "var", name: matchBinder(fi.name, varName) };
     }
     return null;
   };
@@ -956,11 +988,12 @@ function transformPureBody(stmts: TStmt[], typeDecls: TypeDeclInfo[]): Expr | nu
 function transformPureSwitch(s: TStmt & { kind: "switch" }, typeDecls: TypeDeclInfo[]): Expr | null {
   const decl = typeDecls.find(d => d.name === (s.expr.ty.kind === "user" ? s.expr.ty.name : ""));
   if (!decl) return null;
+  const varName = s.expr.kind === "var" ? s.expr.name : undefined;
   const arms: MatchArm[] = [];
   for (const c of s.cases) {
     const variant = decl.variants?.find(v => v.name === c.label);
     const fields = variant?.fields ?? [];
-    const pattern = fields.length > 0 ? `.${c.label} ${fields.map(f => matchBinder(f.name)).join(" ")}` : `.${c.label}`;
+    const pattern = fields.length > 0 ? `.${c.label} ${fields.map(f => matchBinder(f.name, varName)).join(" ")}` : `.${c.label}`;
     let body = transformPureBody(c.body, typeDecls);
     if (!body) return null;
     if (fields.length > 0 && s.expr.kind === "var") body = replaceFieldAccess(body, s.expr.name, fields);
@@ -981,7 +1014,7 @@ function transformPureMatch(chain: Chain, typeDecls: TypeDeclInfo[]): Expr | nul
   for (const c of chain.cases) {
     const variant = decl?.variants?.find(v => v.name === c.variant);
     const fields = variant?.fields ?? [];
-    const pattern = fields.length > 0 ? `.${c.variant} ${fields.map(f => matchBinder(f.name)).join(" ")}` : `.${c.variant}`;
+    const pattern = fields.length > 0 ? `.${c.variant} ${fields.map(f => matchBinder(f.name, chain.varName)).join(" ")}` : `.${c.variant}`;
     let body = transformPureBody(c.body, typeDecls);
     if (!body) return null;
     if (fields.length > 0) body = replaceFieldAccess(body, chain.varName, fields);
@@ -1095,6 +1128,7 @@ export function transformModuleDafny(mod: TModule): { typesFile: Module | null; 
 
 export function transformModule(mod: TModule, specImport?: string): { typesFile: Module | null; defFile: Module } {
   _forofCounters.clear();
+  _typeDecls = mod.typeDecls;
   const typeDecls = mod.typeDecls.map(transformTypeDecl);
 
   // Module-level constants


### PR DESCRIPTION
- Fix variable name collision in nested matches by prefixing binders with scrutinee name
- Convert discriminated union object literals to datatype constructors in transform phase
- Coerce string literal function args to user types (string union → constructor)
- Handle new Set([x]) with initial elements via initElems on emptyCollection
- Use inferred types for new Set()/new Map() when explicit type args are missing
- Detect new Map(existingMap) via type checking and pass through as identity
- Pad missing optional function args with None in resolve phase
- Include | undefined in extracted type for optional parameters (? params)
- Escape function names in Dafny app emission (e.g. true → true_)
- Emit SetLiteral as {a, b} in Dafny